### PR TITLE
DEV: add upper bound on supported Python (#105)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,15 +28,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
       - name: Set up Pixi
-        uses: prefix-dev/setup-pixi@v0.8.10
+        uses: prefix-dev/setup-pixi@v0.9.1
         with:
-          pixi-version: v0.50.2
+          pixi-version: v0.56.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/labeled_tests.yml
+++ b/.github/workflows/labeled_tests.yml
@@ -44,18 +44,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version.version }}
-
       - name: Set up Pixi
-        uses: prefix-dev/setup-pixi@v0.8.10
+        uses: prefix-dev/setup-pixi@v0.9.1
         with:
-          pixi-version: v0.49.0
-
-      - name: Instruct pixi to use specified Python version
-        run: pixi add python=${{ matrix.python-version.version }}
+          pixi-version: v0.56.0
 
       - name: Run ${{ matrix.package }} tests
         run: pixi run -e ${{ matrix.package }}-tests-py${{ matrix.python-version.label }} tests

--- a/.github/workflows/static_code_analysis.yml
+++ b/.github/workflows/static_code_analysis.yml
@@ -21,15 +21,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
       - name: Set up Pixi
-        uses: prefix-dev/setup-pixi@v0.8.10
+        uses: prefix-dev/setup-pixi@v0.9.1
         with:
-          pixi-version: v0.49.0
+          pixi-version: v0.56.0
 
       - name: Install dependencies
         run: pixi install

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,8 +7,6 @@ version: 2
 # Set the OS, Python version, and other tools you might need
 build:
   os: ubuntu-24.04
-  tools:
-    python: "3.13"
   commands:
     - curl -sSf https://pixi.sh/install.sh | sh
     - /home/docs/.pixi/bin/pixi run sphinx-build -T -W -b html -d _build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/pixi.toml
+++ b/pixi.toml
@@ -116,7 +116,7 @@ cmd = "isort ."
 
 [dependencies]
 pandoc = ">=3.7.0.2,<4"
-python = ">=3.10"
+python = ">=3.10,<3.14"
 actionlint = ">=1.7"
 pixi-pycharm = ">=0.0.8,<0.0.9"
 
@@ -128,7 +128,7 @@ deltakit-explorer = { path = "./deltakit-explorer/", editable = true }
 deltakit = { path = "./", editable = true, extras=["dev"] }
 
 [feature.python.dependencies]
-python = ">=3.10"
+python = ">=3.10,<3.14"
 
 [feature.py310.dependencies]
 python = "3.10.*"


### PR DESCRIPTION
* DEV: add upper bound on supported Python

* Update pyproject.toml

* Update .github/workflows/docs.yml

* Update .github/workflows/docs.yml

* Update .github/workflows/static_code_analysis.yml

* CI: no need to install Python before pixi?

* CI: remove unnecessary upper bound?

* CI: remove unnecessary upper bound?

* CI: update setup-pixi and pixi versions

* CI: don't set up Python if not required

* CI: avoid unnecessary command?

* CI: no need for Python on RTD?

* CI: check one last time that we need this constraint

* Revert "CI: check one last time that we need this constraint"

## 🔗 Closed Issues

Link any issues closed or comments addressed by this PR.
"Closes #X" will close issue X automatically when the PR is merged.

---

## 📝 Description

Add any additional description required to understand the PR.
Cite related issues, PRs, or comments as needed.

---

## 🚦 Status

If anything still needs to be done before this PR can be merged, track it here.

---

## 🛠️ Future Work

Focused PRs are good!
Create and link issues for any follow-up work needed.

---

## ➕️ Additional Information

Anything that doesn't fit into a category above.

---

## 🧾 Release Note

If this PR will be **squash-merged**, draft the final one-line commit message here.
Otherwise, describe your rebase strategy or how you plan to maintain clean commits.
